### PR TITLE
fix: runner가 잡힌 후 술래가 되었을 때 player와 runner의 캐릭터 방향

### DIFF
--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -37,7 +37,7 @@ public class Enemy : Player
         }
         if (flowerMsgController.isFlowerEnd())
         {
-            PV.RPC(ENEMY_TURN, RpcTarget.All); // 플레이어 스크립트에 있음
+            PV.RPC(ENEMY_TURN, RpcTarget.All); // 멘트 모두 외치고 러너 바라보도록
         }
     }
 
@@ -63,7 +63,8 @@ public class Enemy : Player
 
                 StartCoroutine(timeDelay(2));
 
-                PV.RPC("colorChangeToRunner", RpcTarget.All);
+                PV.RPC("colorChangeToRunner", RpcTarget.All); // 러너가 된다
+                PV.RPC(ENEMY_TURN, RpcTarget.All); // 러너가 되어서 애너미를 바라봄
             }
         }
 
@@ -97,7 +98,10 @@ public class Enemy : Player
     [PunRPC]
     void enemyTurn()
     {
-        transform.rotation = Quaternion.Euler(0, 180, 0);
+        float view = transform.rotation.z;
+        view = (view + 180) > 180 ? 0 : 180;
+        print(view);
+        transform.rotation = Quaternion.Euler(0, view, 0);
     }
    
 

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -98,12 +98,12 @@ public class Player : MonoBehaviour
         if (speedup)
         {
             speed = 10f; // 빨라지도록
-            print("speedup!");
+            //print("speedup!");
         }
         else
         {
             speed = 5f;
-            print("origin speed");
+            //print("origin speed");
         }
         movement = new Vector3(horizonal, 0f, vertical);
         movement = movement.normalized * speed * Time.deltaTime;


### PR DESCRIPTION
fix : runner가 enemy touch후 enemy가 runner를 잡아서 runner 술래가 된 상황.
바뀐 술래가 벽을 바라보고 러너는 술래를 바라보도록 방향 설정

todo : 술래가 멘트를 다 외친 상태에서 러너가 움직일 때 동작이 이상하게 됨. -> 이상동작 : 술래가 출발선에 오게 되고 러너가 술래자리에 오게됨. 술래와 러너 모두 움직일 수 있는 상태임

이 상황에서 각각의 플레이어들의 방향도 수정 필요
